### PR TITLE
[Feature/18]クエリパラメータの活用、キーワードの空白対策

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,15 @@
 import { SearchBox } from '@/features/github/components/search-box'
 import { Container } from '@/components/container'
 
-export default function Page() {
+type Props = {
+  searchParams: Promise<{ q?: string | string[] | undefined }>
+}
+
+export default async function Page({ searchParams }: Props) {
+  const { q } = await searchParams
+  const keyword =
+    typeof q === 'string' ? q : Array.isArray(q) ? (q[0] ?? '') : ''
+
   return (
     <main className="min-h-screen bg-background">
       <Container className="py-10">
@@ -11,7 +19,7 @@ export default function Page() {
             GitHubのAPIを使用してリポジトリを検索
           </p>
         </header>
-        <SearchBox />
+        <SearchBox initialKeyword={keyword} />
       </Container>
     </main>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { SearchBox } from '@/features/github/components/search-box'
 import { Container } from '@/components/container'
+import { sanitizeKeyword } from '@/lib/sanitize-keyword'
 
 type Props = {
   searchParams: Promise<{ q?: string | string[] | undefined }>
@@ -7,8 +8,8 @@ type Props = {
 
 export default async function Page({ searchParams }: Props) {
   const { q } = await searchParams
-  const keyword =
-    typeof q === 'string' ? q : Array.isArray(q) ? (q[0] ?? '') : ''
+  const rawKeyword = (Array.isArray(q) ? q[0] : q) ?? ''
+  const keyword = sanitizeKeyword(rawKeyword)
 
   return (
     <main className="min-h-screen bg-background">

--- a/src/features/github/api/__tests__/get-repo-list.test.ts
+++ b/src/features/github/api/__tests__/get-repo-list.test.ts
@@ -38,7 +38,7 @@ describe('getRepoListKey', () => {
 
     it('keywordがURLに含まれる', () => {
       expect(getRepoListKey('react hooks', 0, null)).toBe(
-        '/api/github?q=react hooks&page=1',
+        '/api/github?q=reacthooks&page=1',
       )
     })
   })

--- a/src/features/github/api/get-repo-list.ts
+++ b/src/features/github/api/get-repo-list.ts
@@ -1,15 +1,19 @@
 // features/github/api/get-repo-list.ts
 import type { SearchRepositoriesResponse } from '@/features/github/types/github'
 import { BASE_URL } from '@/constants/api'
+import { sanitizeKeyword } from '@/lib/sanitize-keyword'
 
 export const getRepoListKey = (
   keyword: string,
   pageIndex: number,
   prev: SearchRepositoriesResponse | null,
 ): string | null => {
-  if (!keyword) return null
+  const sanitized = sanitizeKeyword(keyword)
+  if (!sanitized) return null
   if (prev && prev.items.length === 0) return null
-  return `${BASE_URL}/api/github?q=${keyword}&page=${pageIndex + 1}`
+  return `${BASE_URL}/api/github?q=${encodeURIComponent(sanitized)}&page=${
+    pageIndex + 1
+  }`
 }
 
 export const getRepoList = async (

--- a/src/features/github/components/search-box.tsx
+++ b/src/features/github/components/search-box.tsx
@@ -1,18 +1,34 @@
 'use client'
 
-import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { RepoList } from '@/features/github/components/repo-list'
 import { SearchForm } from '@/features/github/components/search-form'
 
-export const SearchBox = () => {
-  const [keyword, setKeyword] = useState('')
+type Props = {
+  initialKeyword: string
+}
+
+export const SearchBox = ({ initialKeyword }: Props) => {
+  const router = useRouter()
+
+  const handleSearch = (q: string) => {
+    const keyword = q.trim()
+    if (!keyword) {
+      router.push('/')
+      return
+    }
+    router.push(`/?q=${encodeURIComponent(keyword)}`)
+  }
 
   return (
     <div>
-      <SearchForm onSearch={(q) => setKeyword(q)} />
-
+      <SearchForm
+        key={initialKeyword}
+        defaultValue={initialKeyword}
+        onSearch={handleSearch}
+      />
       <div className="mt-6">
-        <RepoList keyword={keyword} />
+        <RepoList keyword={initialKeyword} />
       </div>
     </div>
   )

--- a/src/features/github/components/search-box.tsx
+++ b/src/features/github/components/search-box.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation'
 import { RepoList } from '@/features/github/components/repo-list'
 import { SearchForm } from '@/features/github/components/search-form'
+import { sanitizeKeyword } from '@/lib/sanitize-keyword'
 
 type Props = {
   initialKeyword: string
@@ -12,7 +13,7 @@ export const SearchBox = ({ initialKeyword }: Props) => {
   const router = useRouter()
 
   const handleSearch = (q: string) => {
-    const keyword = q.trim()
+    const keyword = sanitizeKeyword(q.trim())
     if (!keyword) {
       router.push('/')
       return
@@ -27,6 +28,9 @@ export const SearchBox = ({ initialKeyword }: Props) => {
         defaultValue={initialKeyword}
         onSearch={handleSearch}
       />
+      <p className="mt-2 text-xs text-muted-foreground">
+        ※キーワードは1つだけ指定できます（空白は自動で除去されます）
+      </p>
       <div className="mt-6">
         <RepoList keyword={initialKeyword} />
       </div>

--- a/src/features/github/components/search-box.tsx
+++ b/src/features/github/components/search-box.tsx
@@ -29,7 +29,7 @@ export const SearchBox = ({ initialKeyword }: Props) => {
         onSearch={handleSearch}
       />
       <p className="mt-2 text-xs text-muted-foreground">
-        ※キーワードは1つだけ指定できます（空白は自動で除去されます）
+        ※キーワードは1つだけ指定できます
       </p>
       <div className="mt-6">
         <RepoList keyword={initialKeyword} />

--- a/src/features/github/components/search-form.tsx
+++ b/src/features/github/components/search-form.tsx
@@ -4,8 +4,13 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 
-export const SearchForm = ({ onSearch }: { onSearch: (q: string) => void }) => {
-  const [value, setValue] = useState('')
+type Props = {
+  defaultValue?: string
+  onSearch: (q: string) => void
+}
+
+export const SearchForm = ({ defaultValue = '', onSearch }: Props) => {
+  const [value, setValue] = useState(defaultValue)
   const trimmed = value.trim()
 
   const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {

--- a/src/features/github/hooks/use-repo-list.ts
+++ b/src/features/github/hooks/use-repo-list.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import useSWRInfinite from 'swr/infinite'
 import {
   getRepoList,
@@ -14,6 +15,10 @@ export const useRepoList = (keyword: string) => {
       (pageIndex, prev) => getRepoListKey(keyword, pageIndex, prev),
       getRepoList,
     )
+
+  useEffect(() => {
+    setSize(1)
+  }, [keyword, setSize])
 
   const repos: Repository[] = data ? data.flatMap((page) => page.items) : []
   return { repos, setSize, isValidating }

--- a/src/lib/__tests__/sanitize-keyword.test.ts
+++ b/src/lib/__tests__/sanitize-keyword.test.ts
@@ -12,4 +12,48 @@ describe('sanitizeKeyword', () => {
   it('改行やタブも除去する', () => {
     expect(sanitizeKeyword('re\nac\tt')).toBe('react')
   })
+
+  it('バックスラッシュを除去する', () => {
+    expect(sanitizeKeyword('react\\hooks')).toBe('reacthooks')
+  })
+
+  it('パーセントを除去する', () => {
+    expect(sanitizeKeyword('react%20hooks')).toBe('react20hooks')
+  })
+
+  it('プラスを除去する', () => {
+    expect(sanitizeKeyword('react+hooks')).toBe('reacthooks')
+  })
+
+  it('ハッシュを除去する', () => {
+    expect(sanitizeKeyword('react#hooks')).toBe('reacthooks')
+  })
+
+  it('アンパサンドを除去する', () => {
+    expect(sanitizeKeyword('react&hooks')).toBe('reacthooks')
+  })
+
+  it('イコールを除去する', () => {
+    expect(sanitizeKeyword('react=hooks')).toBe('reacthooks')
+  })
+
+  it('クエスチョンマークを除去する', () => {
+    expect(sanitizeKeyword('react?hooks')).toBe('reacthooks')
+  })
+
+  it('スラッシュを除去する', () => {
+    expect(sanitizeKeyword('react/hooks')).toBe('reacthooks')
+  })
+
+  it('複数の除去対象文字が混在する場合', () => {
+    expect(sanitizeKeyword('re act+ho&oks?')).toBe('reacthooks')
+  })
+
+  it('空文字列はそのまま返す', () => {
+    expect(sanitizeKeyword('')).toBe('')
+  })
+
+  it('除去対象文字のみの場合は空文字列を返す', () => {
+    expect(sanitizeKeyword('  %+#&=?/')).toBe('')
+  })
 })

--- a/src/lib/__tests__/sanitize-keyword.test.ts
+++ b/src/lib/__tests__/sanitize-keyword.test.ts
@@ -1,0 +1,15 @@
+import { sanitizeKeyword } from '@/lib/sanitize-keyword'
+
+describe('sanitizeKeyword', () => {
+  it('半角スペースを除去する', () => {
+    expect(sanitizeKeyword('react hooks')).toBe('reacthooks')
+  })
+
+  it('全角スペースを除去する', () => {
+    expect(sanitizeKeyword('react　hooks')).toBe('reacthooks')
+  })
+
+  it('改行やタブも除去する', () => {
+    expect(sanitizeKeyword('re\nac\tt')).toBe('react')
+  })
+})

--- a/src/lib/sanitize-keyword.ts
+++ b/src/lib/sanitize-keyword.ts
@@ -1,0 +1,2 @@
+export const sanitizeKeyword = (value: string): string =>
+  value.replace(/[\s\u3000]+/g, '')

--- a/src/lib/sanitize-keyword.ts
+++ b/src/lib/sanitize-keyword.ts
@@ -1,2 +1,3 @@
+// NOTE: スペース・全角スペース・URLエンコードで問題になる文字を削除し、正規化する
 export const sanitizeKeyword = (value: string): string =>
-  value.replace(/[\s\u3000]+/g, '')
+  value.replace(/[\s\u3000]+/g, '').replace(/[\\%+#&=?/]/g, '')


### PR DESCRIPTION
## 概要

- UX体験を向上する対策をいくつか実装

## 変更内容

- 一覧の検索にはクエリパラメータを活用（ブラウザバックしても検索結果が表示されるようにした）
- キーワードの入力文字列の正規化処理を追加
  - それに合わせてキーワードは1つまでという文言を追記した

## 確認項目

- [x] `npm run lint` が通る
- [x] `npm run format:check` が通る
- [x] ビルドが成功する
- [x] 動作確認を行った

## スクリーンショット（UI変更がある場合）

## 備考
close #18 